### PR TITLE
El Camino trail, high/lower falls additions, Apple Farm area additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # map-data
 
 Raw map data for the [\#TrailsRoc](https://trailsroc.org/) app and web-based maps.
+
+## Process for adding and updating data
+
+1. Create GPX data in `source/file.gpx`
+    - One track for each trail segment
+    - One waypoint for each POI
+2. Define metadata in GPX
+    - Decide on unique IDs for top level entities (trails, trail systems, and parks). e.g. `trail-elcamino-main`, `tsystem:elcamino`, `park:mponds`
+    - Assign unique IDs to all trail segments and waypoints using naming conventions. Set these as the text of each track/waypoint's `name` element. `ruby query.rb --makeids count` will create a batch of IDs for convenience
+    - Populate the `desc` element of each waypoint with a JSON string of additional metadata
+3. Generate JSON files and populate remaining metadata
+    - Any _new_ trails, trail systems, or parks need to be added to `source/file.json`. POI and additional segments for existing trails do not require JSON file changes
+    - To get started, run `ruby extract_trail_json.rb path-to-gpx-file` and paste the output into the JSON file
+    - Add additional properties to the JSON as needed
+    - Manually define `trailSystem` objects as needed (not currently supported by `extract_trail_json.rb`)
+4. Generate geojson files
+    - `ruby scripts/make_geojson.rb`. Modify `gpx_filenames` array as needed to use only a subset of files, etc. Note that you may need to include some unchanged files to satisfy dependencies if you encounter "ID does not exist" errors
+5. Prepare dataset/tileset/style for review and testing
+    - Upload geojson file(s) to a new or existing test dataset
+    - Create or replace a test tileset with the updated geojson data
+    - Replace the tileset ID in a test styleset with the appropriate tileset ID:
+        - Search the style JSON for `trailsroc.` and replace that string with the tileset ID
+        - Replace all `source-layer` string values with the tileset name
+    - Test the style. Use the Mapbox Studio Preview app, or on studio.mapbox.com click the style's Share button to access some preview URLs
+    - Publish the test style and test app behavior and dataset metadata/search functionality in map.trailsroc.org and the app
+6. Create a pull request
+7. Integrate with the production maps
+    - Run `rebuild.sh`
+    - Create or update a `prod-v1-build1` dataset with the combined geojson file
+    - Export tileset
+    - Ensure the prod outdoors and satellite styles use the updated tileset

--- a/geojson/canal.geojson
+++ b/geojson/canal.geojson
@@ -13834,7 +13834,8 @@
         "trailsroc-name": "High Falls Overlook",
         "trailsroc-shortName": "High Falls",
         "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-south",
-        "trailsroc-allowsDirections": false
+        "trailsroc-allowsDirections": false,
+        "trailsroc-keywords": "high falls"
       },
       "geometry": {
         "coordinates": [
@@ -13852,7 +13853,8 @@
         "trailsroc-name": "Lower Falls Overlook",
         "trailsroc-shortName": "Lower Falls",
         "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-south",
-        "trailsroc-allowsDirections": false
+        "trailsroc-allowsDirections": false,
+        "trailsroc-keywords": "lower falls"
       },
       "geometry": {
         "coordinates": [
@@ -13870,7 +13872,8 @@
         "trailsroc-name": "Lower Falls Overlook",
         "trailsroc-shortName": "Lower Falls",
         "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-south",
-        "trailsroc-allowsDirections": false
+        "trailsroc-allowsDirections": false,
+        "trailsroc-keywords": "lower falls"
       },
       "geometry": {
         "coordinates": [

--- a/geojson/canal.geojson
+++ b/geojson/canal.geojson
@@ -12595,12 +12595,20 @@
         "type": "LineString",
         "coordinates": [
           [
-            -77.611816,
-            43.157607
+            -77.611887,
+            43.15761
           ],
           [
-            -77.610571,
-            43.157492
+            -77.611177,
+            43.157547
+          ],
+          [
+            -77.610632,
+            43.157512
+          ],
+          [
+            -77.610282,
+            43.157553
           ]
         ]
       },
@@ -12751,6 +12759,256 @@
           [
             -77.619545,
             43.198041
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-gv-riverway-south:2483aa93",
+        "trailsroc-trailIDs": "trail-gv-riverway-south",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Genesee Riverway (South)",
+        "trailsroc-shortName": "Genesee Riverway",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "sky"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.621658,
+            43.165092
+          ],
+          [
+            -77.621558,
+            43.164996
+          ],
+          [
+            -77.621419,
+            43.164949
+          ],
+          [
+            -77.621238,
+            43.164676
+          ],
+          [
+            -77.621101,
+            43.164401
+          ],
+          [
+            -77.620947,
+            43.163961
+          ],
+          [
+            -77.620856,
+            43.163847
+          ],
+          [
+            -77.620409,
+            43.163368
+          ],
+          [
+            -77.620207,
+            43.163126
+          ],
+          [
+            -77.620047,
+            43.162806
+          ],
+          [
+            -77.619873,
+            43.162476
+          ],
+          [
+            -77.619576,
+            43.162199
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-gv-riverway-south:bb1754bd",
+        "trailsroc-trailIDs": "trail-gv-riverway-south",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Genesee Riverway (South)",
+        "trailsroc-shortName": "Genesee Riverway",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "sky"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.612555,
+            43.158939
+          ],
+          [
+            -77.612493,
+            43.158806
+          ],
+          [
+            -77.61249,
+            43.158693
+          ],
+          [
+            -77.611888,
+            43.1576
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-gv-riverway-south:adbe8be7",
+        "trailsroc-trailIDs": "trail-gv-riverway-south",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Genesee Riverway (South)",
+        "trailsroc-shortName": "Genesee Riverway",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "sky"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.611888,
+            43.1576
+          ],
+          [
+            -77.611627,
+            43.157112
+          ],
+          [
+            -77.611512,
+            43.15695
+          ],
+          [
+            -77.611365,
+            43.156859
+          ],
+          [
+            -77.611267,
+            43.15685
+          ],
+          [
+            -77.610914,
+            43.156086
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-gv-riverway-south:f9282d1e",
+        "trailsroc-trailIDs": "trail-gv-riverway-south",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Genesee Riverway (South)",
+        "trailsroc-shortName": "Genesee Riverway",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "sky"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.610914,
+            43.156086
+          ],
+          [
+            -77.61064,
+            43.155457
+          ],
+          [
+            -77.610828,
+            43.155329
+          ],
+          [
+            -77.61069,
+            43.154919
+          ],
+          [
+            -77.611329,
+            43.154796
+          ],
+          [
+            -77.611265,
+            43.154691
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-gv-riverway-other:77a6492e",
+        "trailsroc-trailIDs": "trail-gv-riverway-other",
+        "trailsroc-name": "Genesee Riverway (Other Trails)",
+        "trailsroc-shortName": "Genesee Riverway",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "blue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.611625,
+            43.157123
+          ],
+          [
+            -77.611489,
+            43.157202
+          ],
+          [
+            -77.611205,
+            43.157484
+          ],
+          [
+            -77.611201,
+            43.157538
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-gv-riverway-other:0aed8a7f",
+        "trailsroc-trailIDs": "trail-gv-riverway-other",
+        "trailsroc-name": "Genesee Riverway (Other Trails)",
+        "trailsroc-shortName": "Genesee Riverway",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "blue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.613603,
+            43.157049
+          ],
+          [
+            -77.612418,
+            43.15763
+          ],
+          [
+            -77.612255,
+            43.157457
+          ],
+          [
+            -77.611903,
+            43.157601
           ]
         ]
       },
@@ -13393,7 +13651,8 @@
         "trailsroc-name": "Parking (Maplewood)",
         "trailsroc-shortName": "Maplewood",
         "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-maplewood",
-        "trailsroc-allowsDirections": true
+        "trailsroc-allowsDirections": true,
+        "trailsroc-keywords": "lower falls"
       },
       "geometry": {
         "coordinates": [
@@ -13408,10 +13667,11 @@
       "properties": {
         "trailsroc-type": "point-poi",
         "trailsroc-id": "point-poi:canal:footbridge1",
-        "trailsroc-name": "Footbridge",
-        "trailsroc-shortName": "Footbridge",
+        "trailsroc-name": "Pont de Rennes Bridge",
+        "trailsroc-shortName": "Pont de Rennes",
         "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-south",
-        "trailsroc-allowsDirections": false
+        "trailsroc-allowsDirections": false,
+        "trailsroc-keywords": "high falls"
       },
       "geometry": {
         "coordinates": [
@@ -13433,8 +13693,8 @@
       },
       "geometry": {
         "coordinates": [
-          -77.611153,
-          43.15749
+          -77.611125,
+          43.157526
         ],
         "type": "Point"
       },
@@ -13562,6 +13822,60 @@
         "coordinates": [
           -77.429091,
           43.094677
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-scenic",
+        "trailsroc-id": "point-scenic:sriverway:hfalls1",
+        "trailsroc-name": "High Falls Overlook",
+        "trailsroc-shortName": "High Falls",
+        "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-south",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.621096,
+          43.164547
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-scenic",
+        "trailsroc-id": "point-scenic:sriverway:lfalls1",
+        "trailsroc-name": "Lower Falls Overlook",
+        "trailsroc-shortName": "Lower Falls",
+        "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-south",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.628369,
+          43.178915
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-scenic",
+        "trailsroc-id": "point-scenic:sriverway:lfalls2",
+        "trailsroc-name": "Lower Falls Overlook",
+        "trailsroc-shortName": "Lower Falls",
+        "trailsroc-parentIDs": "tsystem-gv-riverway,trail-gv-riverway-south",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.629207,
+          43.180031
         ],
         "type": "Point"
       },

--- a/geojson/city_parks.geojson
+++ b/geojson/city_parks.geojson
@@ -100,7 +100,7 @@
         "trailsroc-parentID": "tsystem-elcamino",
         "trailsroc-name": "El Camino Trail",
         "trailsroc-url": "https://www.geneseelandtrust.org/public-spaces/el-camino",
-        "trailsroc-color": null,
+        "trailsroc-color": "black",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-style": "trailSystem",
         "trailsroc-blazes": "none",
@@ -3930,7 +3930,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -3956,7 +3956,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -3982,7 +3982,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4012,7 +4012,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4038,7 +4038,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4064,7 +4064,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4090,7 +4090,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4116,7 +4116,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4154,7 +4154,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4188,7 +4188,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4222,7 +4222,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4276,7 +4276,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4318,7 +4318,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4348,7 +4348,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",
@@ -4382,7 +4382,7 @@
         "trailsroc-name": "El Camino Trail",
         "trailsroc-shortName": "El Camino Trail",
         "trailsroc-surface": "singletrack",
-        "trailsroc-color": null
+        "trailsroc-color": "black"
       },
       "geometry": {
         "type": "LineString",

--- a/geojson/city_parks.geojson
+++ b/geojson/city_parks.geojson
@@ -3,6 +3,25 @@
   "features": [
     {
       "properties": {
+        "trailsroc-type": "trailSystem",
+        "trailsroc-id": "tsystem-elcamino",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-url": "https://www.geneseelandtrust.org/public-spaces/el-camino",
+        "trailsroc-allowsDirections": true,
+        "trailsroc-isSearchable": true
+      },
+      "geometry": {
+        "coordinates": [
+          -77.617481,
+          43.184036
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
         "trailsroc-type": "park",
         "trailsroc-id": "park-cobbs",
         "trailsroc-shortName": "Cobbs Hill Park",
@@ -69,6 +88,48 @@
         "coordinates": [
           -77.575445,
           43.1393135
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trail",
+        "trailsroc-id": "trail-elcamino-main",
+        "trailsroc-parentID": "tsystem-elcamino",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-url": "https://www.geneseelandtrust.org/public-spaces/el-camino",
+        "trailsroc-color": null,
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-blazes": "none",
+        "trailsroc-isPrimary": true
+      },
+      "geometry": {
+        "coordinates": [
+          -77.6167195,
+          43.1855155
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trail",
+        "trailsroc-id": "trail-elcamino-access",
+        "trailsroc-parentID": "tsystem-elcamino",
+        "trailsroc-name": "El Camino Trail Access",
+        "trailsroc-color": "unmarked_trail",
+        "trailsroc-shortName": "El Camino Access",
+        "trailsroc-blazes": "none",
+        "trailsroc-isSearchable": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.6161625,
+          43.186794
         ],
         "type": "Point"
       },
@@ -3862,6 +3923,612 @@
     },
     {
       "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:39c2eda0",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.618797,
+            43.173149
+          ],
+          [
+            -77.618847,
+            43.173994
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:1dda4af2",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.618847,
+            43.173994
+          ],
+          [
+            -77.618908,
+            43.174741
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:c06c1bd1",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.618908,
+            43.174741
+          ],
+          [
+            -77.619012,
+            43.176222
+          ],
+          [
+            -77.619179,
+            43.177764
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:20c13209",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.619179,
+            43.177764
+          ],
+          [
+            -77.619226,
+            43.178632
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:5acdf442",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.619226,
+            43.178632
+          ],
+          [
+            -77.619284,
+            43.179445
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:69ca5027",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.619284,
+            43.179445
+          ],
+          [
+            -77.619323,
+            43.180277
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:7d5c8fc0",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.619323,
+            43.180277
+          ],
+          [
+            -77.619415,
+            43.181695
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:9a87d877",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.619415,
+            43.181695
+          ],
+          [
+            -77.619487,
+            43.182425
+          ],
+          [
+            -77.619384,
+            43.182879
+          ],
+          [
+            -77.619198,
+            43.183245
+          ],
+          [
+            -77.618866,
+            43.183712
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:c7e79ceb",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.618866,
+            43.183712
+          ],
+          [
+            -77.617147,
+            43.185661
+          ],
+          [
+            -77.617055,
+            43.185816
+          ],
+          [
+            -77.617086,
+            43.186257
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:38b09bfd",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.617086,
+            43.186257
+          ],
+          [
+            -77.616517,
+            43.186274
+          ],
+          [
+            -77.616369,
+            43.186369
+          ],
+          [
+            -77.616053,
+            43.186439
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:31ebc091",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.616053,
+            43.186439
+          ],
+          [
+            -77.615634,
+            43.187083
+          ],
+          [
+            -77.615345,
+            43.187457
+          ],
+          [
+            -77.615199,
+            43.18774
+          ],
+          [
+            -77.615054,
+            43.187902
+          ],
+          [
+            -77.614575,
+            43.188645
+          ],
+          [
+            -77.614319,
+            43.189287
+          ],
+          [
+            -77.614183,
+            43.190171
+          ],
+          [
+            -77.613991,
+            43.191829
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:ae1cf05f",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.613991,
+            43.191829
+          ],
+          [
+            -77.613952,
+            43.192183
+          ],
+          [
+            -77.613958,
+            43.192272
+          ],
+          [
+            -77.614061,
+            43.192635
+          ],
+          [
+            -77.614321,
+            43.193138
+          ],
+          [
+            -77.614512,
+            43.193428
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:6d6e3fc7",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.614512,
+            43.193428
+          ],
+          [
+            -77.616154,
+            43.195874
+          ],
+          [
+            -77.616236,
+            43.196031
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:905bc27d",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.616236,
+            43.196031
+          ],
+          [
+            -77.616284,
+            43.196209
+          ],
+          [
+            -77.616669,
+            43.196633
+          ],
+          [
+            -77.616801,
+            43.196939
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-main:310a7d59",
+        "trailsroc-trailIDs": "trail-elcamino-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "El Camino Trail",
+        "trailsroc-shortName": "El Camino Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": null
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.616801,
+            43.196939
+          ],
+          [
+            -77.616848,
+            43.197128
+          ],
+          [
+            -77.617204,
+            43.19752
+          ],
+          [
+            -77.617309,
+            43.197656
+          ],
+          [
+            -77.617335,
+            43.197793
+          ],
+          [
+            -77.617493,
+            43.197882
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-access:fe27bf5f",
+        "trailsroc-trailIDs": "trail-elcamino-access",
+        "trailsroc-name": "El Camino Trail Access",
+        "trailsroc-shortName": "El Camino Access",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "unmarked_trail"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.618313,
+            43.181763
+          ],
+          [
+            -77.618421,
+            43.181692
+          ],
+          [
+            -77.619417,
+            43.181686
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-access:3aef125e",
+        "trailsroc-trailIDs": "trail-elcamino-access",
+        "trailsroc-name": "El Camino Trail Access",
+        "trailsroc-shortName": "El Camino Access",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "unmarked_trail"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.619449,
+            43.184
+          ],
+          [
+            -77.618872,
+            43.183705
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-access:f9293a98",
+        "trailsroc-trailIDs": "trail-elcamino-access",
+        "trailsroc-name": "El Camino Trail Access",
+        "trailsroc-shortName": "El Camino Access",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "unmarked_trail"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.615173,
+            43.191739
+          ],
+          [
+            -77.613992,
+            43.191828
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-elcamino-access:01f1d5bc",
+        "trailsroc-trailIDs": "trail-elcamino-access",
+        "trailsroc-name": "El Camino Trail Access",
+        "trailsroc-shortName": "El Camino Access",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "unmarked_trail"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.613992,
+            43.191828
+          ],
+          [
+            -77.613816,
+            43.191843
+          ],
+          [
+            -77.613338,
+            43.191839
+          ],
+          [
+            -77.612876,
+            43.191902
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
         "trailsroc-type": "parkBorder",
         "trailsroc-id": "border:park-cobbs:border1",
         "trailsroc-parkID": "park-cobbs"
@@ -4386,6 +5053,79 @@
         "coordinates": [
           -77.574921,
           43.13806
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-poi",
+        "trailsroc-id": "point-poi:elcamino:conkeypark",
+        "trailsroc-name": "Conkey Corner Park",
+        "trailsroc-shortName": "Conkey Corner Park",
+        "trailsroc-parentIDs": "trail-elcamino-main,tsystem-elcamino",
+        "trailsroc-url": "https://www.geneseelandtrust.org/public-spaces/el-camino",
+        "trailsroc-allowsDirections": true
+      },
+      "geometry": {
+        "coordinates": [
+          -77.619249,
+          43.174912
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-sports",
+        "trailsroc-id": "point-sports:elcamino:0114dd34",
+        "trailsroc-name": "Ball Fields",
+        "trailsroc-shortName": "Ball Fields",
+        "trailsroc-parentIDs": "tsystem-elcamino",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.618893,
+          43.181422
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-sports",
+        "trailsroc-id": "point-sports:elcamino:2a70e408",
+        "trailsroc-name": "Tennis Courts",
+        "trailsroc-shortName": "Tennis Courts",
+        "trailsroc-parentIDs": "tsystem-elcamino",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.618963,
+          43.18191
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-sports",
+        "trailsroc-id": "point-sports:elcamino:fca7358f",
+        "trailsroc-name": "Playground",
+        "trailsroc-shortName": "Playground",
+        "trailsroc-parentIDs": "tsystem-elcamino",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.618665,
+          43.180862
         ],
         "type": "Point"
       },

--- a/geojson/senecapk.geojson
+++ b/geojson/senecapk.geojson
@@ -1577,7 +1577,7 @@
         "trailsroc-id": "point-smparking:senecapk:ebridge",
         "trailsroc-name": "Street Parking (near bridge)",
         "trailsroc-shortName": "Street Parking",
-        "trailsroc-parentIDs": "park-senecapk,trail-senecapk-olmsted-s",
+        "trailsroc-parentIDs": "park-senecapk,trail-senecapk-olmsted-s,trail-elcamino-main,tsystem-elcamino",
         "trailsroc-allowsDirections": true
       },
       "geometry": {

--- a/geojson/senecatr.geojson
+++ b/geojson/senecatr.geojson
@@ -59,7 +59,8 @@
         "trailsroc-shortName": "Apple Farm Trail",
         "trailsroc-keywords": "senaca seneca",
         "trailsroc-blazes": "color",
-        "trailsroc-isPrimary": false
+        "trailsroc-isPrimary": false,
+        "trailsroc-isSearchable": true
       },
       "geometry": {
         "coordinates": [
@@ -5512,7 +5513,7 @@
         "trailsroc-name": "Victor Apple Farm",
         "trailsroc-shortName": "Victor Apple Farm",
         "trailsroc-url": "https://www.thevictorapplefarm.com",
-        "trailsroc-allowsDirections": false
+        "trailsroc-allowsDirections": true
       },
       "geometry": {
         "coordinates": [

--- a/geojson/senecatr.geojson
+++ b/geojson/senecatr.geojson
@@ -7,7 +7,7 @@
         "trailsroc-id": "tsystem-senecatr",
         "trailsroc-shortName": "Seneca Trail",
         "trailsroc-name": "Seneca Trail",
-        "trailsroc-url": "http://www.victorhikingtrails.org/",
+        "trailsroc-url": "https://www.victorhikingtrails.org/",
         "trailsroc-allowsDirections": true,
         "trailsroc-isSearchable": true,
         "trailsroc-keywords": "senaca",
@@ -31,7 +31,7 @@
         "trailsroc-id": "trail-senecatr-main",
         "trailsroc-parentID": "tsystem-senecatr",
         "trailsroc-name": "Seneca Trail",
-        "trailsroc-url": "http://www.victorhikingtrails.org/",
+        "trailsroc-url": "https://www.victorhikingtrails.org/",
         "trailsroc-color": "red",
         "trailsroc-shortName": "Seneca Trail",
         "trailsroc-keywords": "senaca",
@@ -43,6 +43,28 @@
         "coordinates": [
           -77.428586,
           42.982133000000005
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trail",
+        "trailsroc-id": "trail-senecatr-apple",
+        "trailsroc-parentID": "tsystem-senecatr",
+        "trailsroc-name": "Apple Farm Trail",
+        "trailsroc-url": "https://www.victorhikingtrails.org/map/trails/apple_farm.php",
+        "trailsroc-color": "yellow",
+        "trailsroc-shortName": "Apple Farm Trail",
+        "trailsroc-keywords": "senaca seneca",
+        "trailsroc-blazes": "color",
+        "trailsroc-isPrimary": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.419893,
+          42.9520995
         ],
         "type": "Point"
       },
@@ -3853,7 +3875,7 @@
     {
       "properties": {
         "trailsroc-type": "trailSegment",
-        "trailsroc-id": "seg:trail-senecatr-main:07d3b899",
+        "trailsroc-id": "seg:trail-senecatr-main:590da387",
         "trailsroc-trailIDs": "trail-senecatr-main",
         "trailsroc-style": "trailSystem",
         "trailsroc-name": "Seneca Trail",
@@ -3887,6 +3909,28 @@
           [
             -77.424069,
             42.960069
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-main:a40a2fd9",
+        "trailsroc-trailIDs": "trail-senecatr-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Seneca Trail",
+        "trailsroc-shortName": "Seneca Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "red"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.424069,
+            42.960069
           ],
           [
             -77.423843,
@@ -3897,8 +3941,30 @@
             42.95937
           ],
           [
-            -77.423881,
-            42.958773
+            -77.423845,
+            42.958871
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-main:07d3b899",
+        "trailsroc-trailIDs": "trail-senecatr-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Seneca Trail",
+        "trailsroc-shortName": "Seneca Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "red"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.423845,
+            42.958871
           ],
           [
             -77.423741,
@@ -3983,6 +4049,28 @@
           [
             -77.425156,
             42.95276
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-main:5336df65",
+        "trailsroc-trailIDs": "trail-senecatr-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Seneca Trail",
+        "trailsroc-shortName": "Seneca Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "red"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.425156,
+            42.95276
           ],
           [
             -77.425104,
@@ -4004,6 +4092,28 @@
             -77.426447,
             42.951194
           ],
+          [
+            -77.425349,
+            42.951405
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-main:2f492902",
+        "trailsroc-trailIDs": "trail-senecatr-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Seneca Trail",
+        "trailsroc-shortName": "Seneca Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "red"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
           [
             -77.425349,
             42.951405
@@ -4773,6 +4883,415 @@
     },
     {
       "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-apple:e99d774f",
+        "trailsroc-trailIDs": "trail-senecatr-apple",
+        "trailsroc-name": "Apple Farm Trail",
+        "trailsroc-shortName": "Apple Farm Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "yellow"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.42515,
+            42.952763
+          ],
+          [
+            -77.425085,
+            42.952769
+          ],
+          [
+            -77.425076,
+            42.952775
+          ],
+          [
+            -77.425044,
+            42.952787
+          ],
+          [
+            -77.42502,
+            42.952791
+          ],
+          [
+            -77.424995,
+            42.952791
+          ],
+          [
+            -77.424983,
+            42.95279
+          ],
+          [
+            -77.424972,
+            42.952788
+          ],
+          [
+            -77.424961,
+            42.952785
+          ],
+          [
+            -77.424951,
+            42.952781
+          ],
+          [
+            -77.424943,
+            42.952776
+          ],
+          [
+            -77.424936,
+            42.95277
+          ],
+          [
+            -77.42493,
+            42.952764
+          ],
+          [
+            -77.424925,
+            42.952757
+          ],
+          [
+            -77.424921,
+            42.95274
+          ],
+          [
+            -77.424921,
+            42.952731
+          ],
+          [
+            -77.424925,
+            42.95271
+          ],
+          [
+            -77.424943,
+            42.952664
+          ],
+          [
+            -77.424949,
+            42.952653
+          ],
+          [
+            -77.42497,
+            42.952604
+          ],
+          [
+            -77.424977,
+            42.952579
+          ],
+          [
+            -77.424981,
+            42.952553
+          ],
+          [
+            -77.424982,
+            42.95254
+          ],
+          [
+            -77.424982,
+            42.952528
+          ],
+          [
+            -77.424981,
+            42.952515
+          ],
+          [
+            -77.424981,
+            42.952502
+          ],
+          [
+            -77.424977,
+            42.952476
+          ],
+          [
+            -77.424976,
+            42.952464
+          ],
+          [
+            -77.42497,
+            42.952425
+          ],
+          [
+            -77.42497,
+            42.952411
+          ],
+          [
+            -77.424969,
+            42.952398
+          ],
+          [
+            -77.424971,
+            42.95237
+          ],
+          [
+            -77.424982,
+            42.952327
+          ],
+          [
+            -77.425002,
+            42.952284
+          ],
+          [
+            -77.425028,
+            42.952241
+          ],
+          [
+            -77.425149,
+            42.952074
+          ],
+          [
+            -77.425288,
+            42.951807
+          ],
+          [
+            -77.4253,
+            42.951777
+          ],
+          [
+            -77.425315,
+            42.951731
+          ],
+          [
+            -77.425322,
+            42.9517
+          ],
+          [
+            -77.425326,
+            42.95167
+          ],
+          [
+            -77.425324,
+            42.951656
+          ],
+          [
+            -77.425308,
+            42.951637
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-apple:9749c77c",
+        "trailsroc-trailIDs": "trail-senecatr-apple",
+        "trailsroc-name": "Apple Farm Trail",
+        "trailsroc-shortName": "Apple Farm Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "yellow"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.425308,
+            42.951637
+          ],
+          [
+            -77.425289,
+            42.95162
+          ],
+          [
+            -77.425266,
+            42.951605
+          ],
+          [
+            -77.425222,
+            42.951587
+          ],
+          [
+            -77.425206,
+            42.951582
+          ],
+          [
+            -77.425151,
+            42.95157
+          ],
+          [
+            -77.424397,
+            42.951512
+          ],
+          [
+            -77.42432,
+            42.951512
+          ],
+          [
+            -77.4243,
+            42.951513
+          ],
+          [
+            -77.424281,
+            42.951513
+          ],
+          [
+            -77.422498,
+            42.951687
+          ],
+          [
+            -77.422477,
+            42.951687
+          ],
+          [
+            -77.422411,
+            42.95169
+          ],
+          [
+            -77.422389,
+            42.95169
+          ],
+          [
+            -77.422367,
+            42.951691
+          ],
+          [
+            -77.422346,
+            42.951691
+          ],
+          [
+            -77.422324,
+            42.951692
+          ],
+          [
+            -77.422281,
+            42.951692
+          ],
+          [
+            -77.42226,
+            42.951693
+          ],
+          [
+            -77.422049,
+            42.951689
+          ],
+          [
+            -77.422034,
+            42.951687
+          ],
+          [
+            -77.42202,
+            42.951687
+          ],
+          [
+            -77.421987,
+            42.951684
+          ],
+          [
+            -77.42198,
+            42.951683
+          ],
+          [
+            -77.421581,
+            42.951717
+          ],
+          [
+            -77.420377,
+            42.951702
+          ],
+          [
+            -77.418971,
+            42.951688
+          ],
+          [
+            -77.418033,
+            42.951594
+          ],
+          [
+            -77.417684,
+            42.951632
+          ],
+          [
+            -77.416462,
+            42.951815
+          ],
+          [
+            -77.415172,
+            42.95201
+          ],
+          [
+            -77.414435,
+            42.952062
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-apple:7c17085a",
+        "trailsroc-trailIDs": "trail-senecatr-apple",
+        "trailsroc-name": "Apple Farm Trail",
+        "trailsroc-shortName": "Apple Farm Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "yellow"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.42531,
+            42.951633
+          ],
+          [
+            -77.425351,
+            42.951408
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "trailSegment",
+        "trailsroc-id": "seg:trail-senecatr-main:e8d927ee",
+        "trailsroc-trailIDs": "trail-senecatr-main",
+        "trailsroc-style": "trailSystem",
+        "trailsroc-name": "Seneca Trail",
+        "trailsroc-shortName": "Seneca Trail",
+        "trailsroc-surface": "singletrack",
+        "trailsroc-color": "red"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -77.423852,
+            42.958874
+          ],
+          [
+            -77.4241,
+            42.958881
+          ],
+          [
+            -77.424144,
+            42.958931
+          ],
+          [
+            -77.424098,
+            42.959126
+          ],
+          [
+            -77.424108,
+            42.959192
+          ],
+          [
+            -77.42418,
+            42.959389
+          ],
+          [
+            -77.424166,
+            42.959688
+          ],
+          [
+            -77.424069,
+            42.960068
+          ]
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
         "trailsroc-type": "point-parking",
         "trailsroc-id": "point-parking:senecatr:8e23a429",
         "trailsroc-name": "Parking (trail access behind Bed/Bath/Beyond)",
@@ -4962,6 +5481,97 @@
         "coordinates": [
           -77.439897,
           43.033274
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-sports",
+        "trailsroc-id": "point-sports:senecatr:discgolf",
+        "trailsroc-name": "Disc Golf Course",
+        "trailsroc-shortName": "Disc Golf Course",
+        "trailsroc-parentIDs": "tsystem-senecatr,trail-senecatr-main,trail-senecatr-apple",
+        "trailsroc-url": "https://grdgc.org/courses/apple-farm-spartan-dgc",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.420781,
+          42.952366
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-poi",
+        "trailsroc-id": "point-poi:senecatr:applefarm",
+        "trailsroc-name": "Victor Apple Farm",
+        "trailsroc-shortName": "Victor Apple Farm",
+        "trailsroc-url": "https://www.thevictorapplefarm.com",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.41214,
+          42.952449
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-scenic",
+        "trailsroc-id": "point-scenic:senecatr:greatbrook",
+        "trailsroc-name": "Great Brook",
+        "trailsroc-shortName": "Great Brook",
+        "trailsroc-parentIDs": "tsystem-senecatr,trail-senecatr-main",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.424126,
+          42.956475
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-scenic",
+        "trailsroc-id": "point-scenic:senecatr:gbrookbridge",
+        "trailsroc-name": "Great Brook Bridge",
+        "trailsroc-shortName": "Bridge",
+        "trailsroc-parentIDs": "tsystem-senecatr,trail-senecatr-main",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.425227,
+          42.95281
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "trailsroc-type": "point-scenic",
+        "trailsroc-id": "point-scenic:senecatr:beaverpond",
+        "trailsroc-name": "Beaver Pond/Picnic Table",
+        "trailsroc-shortName": "Beaver Pond",
+        "trailsroc-parentIDs": "tsystem-senecatr,trail-senecatr-main",
+        "trailsroc-allowsDirections": false
+      },
+      "geometry": {
+        "coordinates": [
+          -77.426409,
+          42.951132
         ],
         "type": "Point"
       },

--- a/scripts/query.rb
+++ b/scripts/query.rb
@@ -3,6 +3,11 @@
 require 'json'
 
 def process(query_terms, file_paths)
+    if IDGenerator.handles(query_terms)
+        IDGenerator.new().process(file_paths)
+        return
+    end
+
     query = GeoJSONQuery.new(query_terms)
 
     file_paths.each do |path|
@@ -80,7 +85,28 @@ class GeoJSONQuery
     end
 end
 
+class IDGenerator
+    def self.handles(query_text)
+        query_text == "--makeids"
+    end
+
+    def random_id()
+        $r.bytes(4).unpack("H*")[0]
+    end
+
+    def process(argv)
+        # argv[0] == number of IDs. default to 1
+        num_ids = argv[0].to_i
+        num_ids = 1 if num_ids < 1
+        num_ids.times do
+            print "#{self.random_id()}\n"
+        end
+    end
+end
+
 # General helpers ################################
+
+$r = Random.new
 
 def error_msg(msg, o)
     $stderr.puts msg
@@ -147,6 +173,10 @@ List of all properties used by points of interest:
 $ ruby query.rb poi.@keys *.geojson | cut -d : -f 2- | sort -u
 List of geojson files that have some obsolete property:
 $ ruby query.rb ?bogus *.geojson | cut -d : -f 1 | sort -u
+
+Other commands:
+$ ruby query.rb --makeids 20
+Creates 20 random 8-character strings for use in feature IDs.
 
 USAGE
 

--- a/scripts/query.rb
+++ b/scripts/query.rb
@@ -161,22 +161,29 @@ Examples:
 
 Count total number of features:
 $ ruby query.rb . *.geojson | wc -l
+
 List of all trail colors ("cut" removes the filenames):
 $ ruby query.rb .color *.geojson | cut -d : -f 2- | sort -u
+
 List of all POI types:
 $ ruby query.rb poi.type *.geojson | cut -d : -f 2- | sort -u
+
 List of all park names:
 $ ruby query.rb park.name *.geojson
+
 List of features that have any search keywords:
-$ ruby query.rb ?keywords *.geojson
+$ ruby query.rb '?keywords' *.geojson
+
 List of all properties used by points of interest:
 $ ruby query.rb poi.@keys *.geojson | cut -d : -f 2- | sort -u
-List of geojson files that have some obsolete property:
-$ ruby query.rb ?bogus *.geojson | cut -d : -f 1 | sort -u
+
+List of geojson files that have some obsolete property named "bogus":
+$ ruby query.rb '?bogus' *.geojson | cut -d : -f 1 | sort -u
 
 Other commands:
+
+Creates 20 random 8-character strings for use in feature IDs:
 $ ruby query.rb --makeids 20
-Creates 20 random 8-character strings for use in feature IDs.
 
 USAGE
 

--- a/source/canal.gpx
+++ b/source/canal.gpx
@@ -2,7 +2,7 @@
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" creator="Adze - http://kobotsw.com/apps/adze" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd">
     <metadata>
         <name>Untitled Document</name>
-        <time>2017-12-28T00:14:33.563Z</time>
+        <time>2020-06-10T13:10:59.946Z</time>
     </metadata>
     <wpt lon="-78.021728" lat="43.227844">
         <name>point-parking:canal:b53cb311</name>
@@ -146,13 +146,13 @@
     </wpt>
     <wpt lon="-77.630282" lat="43.181457">
         <name>point-parking:canal:6d8ae0d0</name>
-        <desc>{"name":"Parking (Maplewood)","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-maplewood"],"shortName":"Maplewood"}</desc>
+        <desc>{"name":"Parking (Maplewood)","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-maplewood"],"shortName":"Maplewood","keywords":"lower falls"}</desc>
     </wpt>
     <wpt lon="-77.615641" lat="43.162423">
         <name>point-poi:canal:footbridge1</name>
-        <desc>{"name":"Footbridge","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
+        <desc>{"name":"Pont de Rennes Bridge","shortName":"Pont de Rennes","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"],"keywords":"high falls"}</desc>
     </wpt>
-    <wpt lon="-77.611153" lat="43.157490">
+    <wpt lon="-77.611125" lat="43.157526">
         <name>point-poi:canal:footbridge2</name>
         <desc>{"name":"Footbridge","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
     </wpt>
@@ -183,6 +183,18 @@
     <wpt lon="-77.429091" lat="43.094677">
         <name>point-poi:cobbs:trolleybridge</name>
         <desc>{"name":"Footbridge","parentIDs":["trail-ecanal-main","tsystem-ecanal","trail-crescenttr-yellow"],"shortName":"Footbridge"}</desc>
+    </wpt>
+    <wpt lon="-77.621096" lat="43.164547">
+        <name>point-scenic:sriverway:hfalls1</name>
+        <desc>{"name":"High Falls Overlook","shortName":"High Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
+    </wpt>
+    <wpt lon="-77.628369" lat="43.178915">
+        <name>point-scenic:sriverway:lfalls1</name>
+        <desc>{"name":"Lower Falls Overlook","shortName":"Lower Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
+    </wpt>
+    <wpt lon="-77.629207" lat="43.180031">
+        <name>point-scenic:sriverway:lfalls2</name>
+        <desc>{"name":"Lower Falls Overlook","shortName":"Lower Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
     </wpt>
     <rte>
         <name>seg:trail-gv-riverway-east:9437ed00</name>
@@ -4463,14 +4475,15 @@
     </trk>
     <trk>
         <name>seg:trail-gv-riverway-other:4d5057fe</name>
-        <extensions>
-            <gpxx:TrackExtension>
+        <extensions>DarkYellow<gpxx:TrackExtension>
                 <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.611816" lat="43.157607"></trkpt>
-            <trkpt lon="-77.610571" lat="43.157492"></trkpt>
+            <trkpt lon="-77.611887" lat="43.157610"></trkpt>
+            <trkpt lon="-77.611177" lat="43.157547"></trkpt>
+            <trkpt lon="-77.610632" lat="43.157512"></trkpt>
+            <trkpt lon="-77.610282" lat="43.157553"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -4532,6 +4545,100 @@
         <trkseg>
             <trkpt lon="-77.622020" lat="43.197677"></trkpt>
             <trkpt lon="-77.619545" lat="43.198041"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-gv-riverway-south:2483aa93</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>Yellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.621658" lat="43.165092"></trkpt>
+            <trkpt lon="-77.621558" lat="43.164996"></trkpt>
+            <trkpt lon="-77.621419" lat="43.164949"></trkpt>
+            <trkpt lon="-77.621238" lat="43.164676"></trkpt>
+            <trkpt lon="-77.621101" lat="43.164401"></trkpt>
+            <trkpt lon="-77.620947" lat="43.163961"></trkpt>
+            <trkpt lon="-77.620856" lat="43.163847"></trkpt>
+            <trkpt lon="-77.620409" lat="43.163368"></trkpt>
+            <trkpt lon="-77.620207" lat="43.163126"></trkpt>
+            <trkpt lon="-77.620047" lat="43.162806"></trkpt>
+            <trkpt lon="-77.619873" lat="43.162476"></trkpt>
+            <trkpt lon="-77.619576" lat="43.162199"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-gv-riverway-south:bb1754bd</name>
+        <extensions>DarkGreen<gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkGreen</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.612555" lat="43.158939"></trkpt>
+            <trkpt lon="-77.612493" lat="43.158806"></trkpt>
+            <trkpt lon="-77.612490" lat="43.158693"></trkpt>
+            <trkpt lon="-77.611888" lat="43.157600"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-gv-riverway-south:adbe8be7</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.611888" lat="43.157600"></trkpt>
+            <trkpt lon="-77.611627" lat="43.157112"></trkpt>
+            <trkpt lon="-77.611512" lat="43.156950"></trkpt>
+            <trkpt lon="-77.611365" lat="43.156859"></trkpt>
+            <trkpt lon="-77.611267" lat="43.156850"></trkpt>
+            <trkpt lon="-77.610914" lat="43.156086"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-gv-riverway-south:f9282d1e</name>
+        <extensions>DarkGreen<gpxx:TrackExtension>
+                <gpxx:DisplayColor>Blue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.610914" lat="43.156086"></trkpt>
+            <trkpt lon="-77.610640" lat="43.155457"></trkpt>
+            <trkpt lon="-77.610828" lat="43.155329"></trkpt>
+            <trkpt lon="-77.610690" lat="43.154919"></trkpt>
+            <trkpt lon="-77.611329" lat="43.154796"></trkpt>
+            <trkpt lon="-77.611265" lat="43.154691"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-gv-riverway-other:77a6492e</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkMagenta</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.611625" lat="43.157123"></trkpt>
+            <trkpt lon="-77.611489" lat="43.157202"></trkpt>
+            <trkpt lon="-77.611205" lat="43.157484"></trkpt>
+            <trkpt lon="-77.611201" lat="43.157538"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-gv-riverway-other:0aed8a7f</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>Magenta</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.613603" lat="43.157049"></trkpt>
+            <trkpt lon="-77.612418" lat="43.157630"></trkpt>
+            <trkpt lon="-77.612255" lat="43.157457"></trkpt>
+            <trkpt lon="-77.611903" lat="43.157601"></trkpt>
         </trkseg>
     </trk>
 </gpx>

--- a/source/canal.gpx
+++ b/source/canal.gpx
@@ -186,15 +186,15 @@
     </wpt>
     <wpt lon="-77.621096" lat="43.164547">
         <name>point-scenic:sriverway:hfalls1</name>
-        <desc>{"name":"High Falls Overlook","shortName":"High Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
+        <desc>{"name":"High Falls Overlook","shortName":"High Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"],"keywords":"high falls"}</desc>
     </wpt>
     <wpt lon="-77.628369" lat="43.178915">
         <name>point-scenic:sriverway:lfalls1</name>
-        <desc>{"name":"Lower Falls Overlook","shortName":"Lower Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
+        <desc>{"name":"Lower Falls Overlook","shortName":"Lower Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"],"keywords":"lower falls"}</desc>
     </wpt>
     <wpt lon="-77.629207" lat="43.180031">
         <name>point-scenic:sriverway:lfalls2</name>
-        <desc>{"name":"Lower Falls Overlook","shortName":"Lower Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"]}</desc>
+        <desc>{"name":"Lower Falls Overlook","shortName":"Lower Falls","parentIDs":["tsystem-gv-riverway","trail-gv-riverway-south"],"keywords":"lower falls"}</desc>
     </wpt>
     <rte>
         <name>seg:trail-gv-riverway-east:9437ed00</name>

--- a/source/city_parks.gpx
+++ b/source/city_parks.gpx
@@ -1556,4 +1556,279 @@
             </trkpt>
         </trkseg>
     </trk>
+
+    <trk>
+        <name>seg:trail-elcamino-main:39c2eda0</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.618797" lat="43.173149"></trkpt>
+            <trkpt lon="-77.618847" lat="43.173994"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:1dda4af2</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.618847" lat="43.173994"></trkpt>
+            <trkpt lon="-77.618908" lat="43.174741"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:c06c1bd1</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.618908" lat="43.174741"></trkpt>
+            <trkpt lon="-77.619012" lat="43.176222"></trkpt>
+            <trkpt lon="-77.619179" lat="43.177764"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:20c13209</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.619179" lat="43.177764"></trkpt>
+            <trkpt lon="-77.619226" lat="43.178632"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:5acdf442</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.619226" lat="43.178632"></trkpt>
+            <trkpt lon="-77.619284" lat="43.179445"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:69ca5027</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.619284" lat="43.179445"></trkpt>
+            <trkpt lon="-77.619323" lat="43.180277"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:7d5c8fc0</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.619323" lat="43.180277"></trkpt>
+            <trkpt lon="-77.619415" lat="43.181695"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:9a87d877</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.619415" lat="43.181695"></trkpt>
+            <trkpt lon="-77.619487" lat="43.182425"></trkpt>
+            <trkpt lon="-77.619384" lat="43.182879"></trkpt>
+            <trkpt lon="-77.619198" lat="43.183245"></trkpt>
+            <trkpt lon="-77.618866" lat="43.183712"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:c7e79ceb</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.618866" lat="43.183712"></trkpt>
+            <trkpt lon="-77.617147" lat="43.185661"></trkpt>
+            <trkpt lon="-77.617055" lat="43.185816"></trkpt>
+            <trkpt lon="-77.617086" lat="43.186257"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:38b09bfd</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.617086" lat="43.186257"></trkpt>
+            <trkpt lon="-77.616517" lat="43.186274"></trkpt>
+            <trkpt lon="-77.616369" lat="43.186369"></trkpt>
+            <trkpt lon="-77.616053" lat="43.186439"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:31ebc091</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.616053" lat="43.186439"></trkpt>
+            <trkpt lon="-77.615634" lat="43.187083"></trkpt>
+            <trkpt lon="-77.615345" lat="43.187457"></trkpt>
+            <trkpt lon="-77.615199" lat="43.187740"></trkpt>
+            <trkpt lon="-77.615054" lat="43.187902"></trkpt>
+            <trkpt lon="-77.614575" lat="43.188645"></trkpt>
+            <trkpt lon="-77.614319" lat="43.189287"></trkpt>
+            <trkpt lon="-77.614183" lat="43.190171"></trkpt>
+            <trkpt lon="-77.613991" lat="43.191829"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:ae1cf05f</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.613991" lat="43.191829"></trkpt>
+            <trkpt lon="-77.613952" lat="43.192183"></trkpt>
+            <trkpt lon="-77.613958" lat="43.192272"></trkpt>
+            <trkpt lon="-77.614061" lat="43.192635"></trkpt>
+            <trkpt lon="-77.614321" lat="43.193138"></trkpt>
+            <trkpt lon="-77.614512" lat="43.193428"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:6d6e3fc7</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.614512" lat="43.193428"></trkpt>
+            <trkpt lon="-77.616154" lat="43.195874"></trkpt>
+            <trkpt lon="-77.616236" lat="43.196031"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:905bc27d</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.616236" lat="43.196031"></trkpt>
+            <trkpt lon="-77.616284" lat="43.196209"></trkpt>
+            <trkpt lon="-77.616669" lat="43.196633"></trkpt>
+            <trkpt lon="-77.616801" lat="43.196939"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-main:310a7d59</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkBlue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.616801" lat="43.196939"></trkpt>
+            <trkpt lon="-77.616848" lat="43.197128"></trkpt>
+            <trkpt lon="-77.617204" lat="43.197520"></trkpt>
+            <trkpt lon="-77.617309" lat="43.197656"></trkpt>
+            <trkpt lon="-77.617335" lat="43.197793"></trkpt>
+            <trkpt lon="-77.617493" lat="43.197882"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-access:fe27bf5f</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.618313" lat="43.181763"></trkpt>
+            <trkpt lon="-77.618421" lat="43.181692"></trkpt>
+            <trkpt lon="-77.619417" lat="43.181686"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-access:3aef125e</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.619449" lat="43.184000"></trkpt>
+            <trkpt lon="-77.618872" lat="43.183705"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-access:f9293a98</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.615173" lat="43.191739"></trkpt>
+            <trkpt lon="-77.613992" lat="43.191828"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-elcamino-access:01f1d5bc</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.613992" lat="43.191828"></trkpt>
+            <trkpt lon="-77.613816" lat="43.191843"></trkpt>
+            <trkpt lon="-77.613338" lat="43.191839"></trkpt>
+            <trkpt lon="-77.612876" lat="43.191902"></trkpt>
+        </trkseg>
+    </trk>
+
+    <wpt lon="-77.619249" lat="43.174912">
+        <name>point-poi:elcamino:conkeypark</name>
+        <desc>{"name":"Conkey Corner Park","parentIDs":["trail-elcamino-main","tsystem-elcamino"],"url":"https://www.geneseelandtrust.org/public-spaces/el-camino","allowsDirections":true}</desc>
+    </wpt>
+    <wpt lon="-77.618893" lat="43.181422">
+        <name>point-sports:elcamino:0114dd34</name>
+        <desc>{"name":"Ball Fields","parentIDs":["tsystem-elcamino"]}</desc>
+    </wpt>
+    <wpt lon="-77.618963" lat="43.181910">
+        <name>point-sports:elcamino:2a70e408</name>
+        <desc>{"name":"Tennis Courts","parentIDs":["tsystem-elcamino"]}</desc>
+    </wpt>
+    <wpt lon="-77.618665" lat="43.180862">
+        <name>point-sports:elcamino:fca7358f</name>
+        <desc>{"name":"Playground","parentIDs":["tsystem-elcamino"]}</desc>
+    </wpt>
 </gpx>

--- a/source/city_parks.json
+++ b/source/city_parks.json
@@ -1,6 +1,24 @@
 {
   "version": 5,
   "trailSystems": {
+    "tsystem-elcamino": {
+      "name": "El Camino Trail",
+      "mainPin": [
+        43.184036,
+        -77.617481
+      ],
+      "url": "https://www.geneseelandtrust.org/public-spaces/el-camino",
+      "directionsCoordinate": null,
+      "SW": [
+        43.173149,
+        -77.619487
+      ],
+      "NE": [
+        43.197882,
+        -77.613952
+      ],
+      "isSearchable": true
+    }
   },
   "parks": {
     "park-cobbs": {
@@ -62,6 +80,38 @@
         -77.573697
       ],
       "parentID": "park-cobbs"
+    },
+    "trail-elcamino-main": {
+      "name": "El Camino Trail",
+      "url": "https://www.geneseelandtrust.org/public-spaces/el-camino",
+      "SW": [
+        43.173149,
+        -77.619487
+      ],
+      "NE": [
+        43.197882,
+        -77.613952
+      ],
+      "blazes": "none",
+      "style": "trailSystem",
+      "isPrimary": true,
+      "parentID": "tsystem-elcamino"
+    },
+    "trail-elcamino-access": {
+      "name": "El Camino Trail Access",
+      "shortName": "El Camino Access",
+      "color": "unmarked_trail",
+      "isSearchable": false,
+      "SW": [
+        43.181686,
+        -77.619449
+      ],
+      "NE": [
+        43.191902,
+        -77.612876
+      ],
+      "blazes": "none",
+      "parentID": "tsystem-elcamino"
     }
   }
 }

--- a/source/city_parks.json
+++ b/source/city_parks.json
@@ -83,6 +83,7 @@
     },
     "trail-elcamino-main": {
       "name": "El Camino Trail",
+      "color": "black",
       "url": "https://www.geneseelandtrust.org/public-spaces/el-camino",
       "SW": [
         43.173149,

--- a/source/senecapk.gpx
+++ b/source/senecapk.gpx
@@ -66,7 +66,7 @@
     </wpt>
     <wpt lon="-77.619125" lat="43.198167">
         <name>point-smparking:senecapk:ebridge</name>
-        <desc>{"type":"point-parking","comments":"Zoo S","name":"Street Parking (near bridge)","shortName":"Street Parking","parentIDs":["park-senecapk","trail-senecapk-olmsted-s"]}</desc>
+        <desc>{"type":"point-parking","comments":"Zoo S","name":"Street Parking (near bridge)","shortName":"Street Parking","parentIDs":["park-senecapk","trail-senecapk-olmsted-s","trail-elcamino-main","tsystem-elcamino"]}</desc>
     </wpt>
     <rte>
         <name>seg:trail-senecapk-gorge-overlook:8a9027f9</name>

--- a/source/senecatr.gpx
+++ b/source/senecatr.gpx
@@ -6605,7 +6605,7 @@
     </wpt>
     <wpt lon="-77.412140" lat="42.952449">
         <name>point-poi:senecatr:applefarm</name>
-        <desc>{"name":"Victor Apple Farm","url":"https://www.thevictorapplefarm.com"}</desc>
+        <desc>{"name":"Victor Apple Farm","url":"https://www.thevictorapplefarm.com","allowsDirections":true}</desc>
     </wpt>
     <wpt lon="-77.424126" lat="42.956475">
         <name>point-scenic:senecatr:greatbrook</name>

--- a/source/senecatr.gpx
+++ b/source/senecatr.gpx
@@ -4923,13 +4923,13 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.425057" lat="42.965949"/>
-            <trkpt lon="-77.424809" lat="42.965067"/>
-            <trkpt lon="-77.424717" lat="42.964723"/>
-            <trkpt lon="-77.424638" lat="42.963966"/>
-            <trkpt lon="-77.424490" lat="42.961707"/>
-            <trkpt lon="-77.424547" lat="42.961570"/>
-            <trkpt lon="-77.425367" lat="42.961392"/>
+            <trkpt lon="-77.425057" lat="42.965949"></trkpt>
+            <trkpt lon="-77.424809" lat="42.965067"></trkpt>
+            <trkpt lon="-77.424717" lat="42.964723"></trkpt>
+            <trkpt lon="-77.424638" lat="42.963966"></trkpt>
+            <trkpt lon="-77.424490" lat="42.961707"></trkpt>
+            <trkpt lon="-77.424547" lat="42.961570"></trkpt>
+            <trkpt lon="-77.425367" lat="42.961392"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -4940,8 +4940,8 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.425367" lat="42.961392"/>
-            <trkpt lon="-77.425151" lat="42.960287"/>
+            <trkpt lon="-77.425367" lat="42.961392"></trkpt>
+            <trkpt lon="-77.425151" lat="42.960287"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -5865,6 +5865,36 @@
         </trkseg>
     </trk>
     <trk>
+        <name>seg:trail-senecatr-main:590da387</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkRed</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.425156" lat="42.960260"></trkpt>
+            <trkpt lon="-77.424736" lat="42.960169"></trkpt>
+            <trkpt lon="-77.424444" lat="42.960163"></trkpt>
+            <trkpt lon="-77.424155" lat="42.960250"></trkpt>
+            <trkpt lon="-77.424071" lat="42.960206"></trkpt>
+            <trkpt lon="-77.424069" lat="42.960069"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-senecatr-main:a40a2fd9</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>Red</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.424069" lat="42.960069"></trkpt>
+            <trkpt lon="-77.423843" lat="42.959803"></trkpt>
+            <trkpt lon="-77.423677" lat="42.959370"></trkpt>
+            <trkpt lon="-77.423845" lat="42.958871"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
         <name>seg:trail-senecatr-main:07d3b899</name>
         <extensions>
             <gpxx:TrackExtension>
@@ -5872,44 +5902,58 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.425156" lat="42.960260"/>
-            <trkpt lon="-77.424736" lat="42.960169"/>
-            <trkpt lon="-77.424444" lat="42.960163"/>
-            <trkpt lon="-77.424155" lat="42.960250"/>
-            <trkpt lon="-77.424071" lat="42.960206"/>
-            <trkpt lon="-77.424069" lat="42.960069"/>
-            <trkpt lon="-77.423843" lat="42.959803"/>
-            <trkpt lon="-77.423677" lat="42.959370"/>
-            <trkpt lon="-77.423881" lat="42.958773"/>
-            <trkpt lon="-77.423741" lat="42.958481"/>
-            <trkpt lon="-77.423494" lat="42.958366"/>
-            <trkpt lon="-77.423980" lat="42.957522"/>
-            <trkpt lon="-77.424126" lat="42.957333"/>
-            <trkpt lon="-77.424216" lat="42.957102"/>
-            <trkpt lon="-77.424178" lat="42.956903"/>
-            <trkpt lon="-77.424257" lat="42.956625"/>
-            <trkpt lon="-77.424726" lat="42.956426"/>
-            <trkpt lon="-77.425091" lat="42.956228"/>
-            <trkpt lon="-77.425454" lat="42.955982"/>
-            <trkpt lon="-77.425792" lat="42.955681"/>
-            <trkpt lon="-77.425848" lat="42.955483"/>
-            <trkpt lon="-77.425770" lat="42.955254"/>
-            <trkpt lon="-77.425656" lat="42.954951"/>
-            <trkpt lon="-77.425626" lat="42.954620"/>
-            <trkpt lon="-77.425716" lat="42.954427"/>
-            <trkpt lon="-77.425670" lat="42.953968"/>
-            <trkpt lon="-77.425651" lat="42.953615"/>
-            <trkpt lon="-77.425508" lat="42.953302"/>
-            <trkpt lon="-77.425382" lat="42.953199"/>
-            <trkpt lon="-77.425156" lat="42.952760"/>
-            <trkpt lon="-77.425104" lat="42.952310"/>
-            <trkpt lon="-77.425902" lat="42.951787"/>
-            <trkpt lon="-77.426622" lat="42.951635"/>
-            <trkpt lon="-77.426652" lat="42.951386"/>
-            <trkpt lon="-77.426447" lat="42.951194"/>
-            <trkpt lon="-77.425349" lat="42.951405"/>
-            <trkpt lon="-77.424859" lat="42.951320"/>
-            <trkpt lon="-77.424394" lat="42.951345"/>
+            <trkpt lon="-77.423845" lat="42.958871"></trkpt>
+            <trkpt lon="-77.423741" lat="42.958481"></trkpt>
+            <trkpt lon="-77.423494" lat="42.958366"></trkpt>
+            <trkpt lon="-77.423980" lat="42.957522"></trkpt>
+            <trkpt lon="-77.424126" lat="42.957333"></trkpt>
+            <trkpt lon="-77.424216" lat="42.957102"></trkpt>
+            <trkpt lon="-77.424178" lat="42.956903"></trkpt>
+            <trkpt lon="-77.424257" lat="42.956625"></trkpt>
+            <trkpt lon="-77.424726" lat="42.956426"></trkpt>
+            <trkpt lon="-77.425091" lat="42.956228"></trkpt>
+            <trkpt lon="-77.425454" lat="42.955982"></trkpt>
+            <trkpt lon="-77.425792" lat="42.955681"></trkpt>
+            <trkpt lon="-77.425848" lat="42.955483"></trkpt>
+            <trkpt lon="-77.425770" lat="42.955254"></trkpt>
+            <trkpt lon="-77.425656" lat="42.954951"></trkpt>
+            <trkpt lon="-77.425626" lat="42.954620"></trkpt>
+            <trkpt lon="-77.425716" lat="42.954427"></trkpt>
+            <trkpt lon="-77.425670" lat="42.953968"></trkpt>
+            <trkpt lon="-77.425651" lat="42.953615"></trkpt>
+            <trkpt lon="-77.425508" lat="42.953302"></trkpt>
+            <trkpt lon="-77.425382" lat="42.953199"></trkpt>
+            <trkpt lon="-77.425156" lat="42.952760"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-senecatr-main:5336df65</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>Blue</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.425156" lat="42.952760"></trkpt>
+            <trkpt lon="-77.425104" lat="42.952310"></trkpt>
+            <trkpt lon="-77.425902" lat="42.951787"></trkpt>
+            <trkpt lon="-77.426622" lat="42.951635"></trkpt>
+            <trkpt lon="-77.426652" lat="42.951386"></trkpt>
+            <trkpt lon="-77.426447" lat="42.951194"></trkpt>
+            <trkpt lon="-77.425349" lat="42.951405"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-senecatr-main:2f492902</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.425349" lat="42.951405"></trkpt>
+            <trkpt lon="-77.424859" lat="42.951320"></trkpt>
+            <trkpt lon="-77.424394" lat="42.951345"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -5920,19 +5964,19 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.424394" lat="42.951345"/>
-            <trkpt lon="-77.424298" lat="42.951291"/>
-            <trkpt lon="-77.424083" lat="42.951082"/>
-            <trkpt lon="-77.423958" lat="42.950771"/>
-            <trkpt lon="-77.423889" lat="42.950394"/>
-            <trkpt lon="-77.423554" lat="42.950237"/>
-            <trkpt lon="-77.423121" lat="42.950381"/>
-            <trkpt lon="-77.422603" lat="42.950367"/>
-            <trkpt lon="-77.422231" lat="42.950251"/>
-            <trkpt lon="-77.421998" lat="42.950077"/>
-            <trkpt lon="-77.421395" lat="42.950014"/>
-            <trkpt lon="-77.420638" lat="42.950337"/>
-            <trkpt lon="-77.419765" lat="42.950433"/>
+            <trkpt lon="-77.424394" lat="42.951345"></trkpt>
+            <trkpt lon="-77.424298" lat="42.951291"></trkpt>
+            <trkpt lon="-77.424083" lat="42.951082"></trkpt>
+            <trkpt lon="-77.423958" lat="42.950771"></trkpt>
+            <trkpt lon="-77.423889" lat="42.950394"></trkpt>
+            <trkpt lon="-77.423554" lat="42.950237"></trkpt>
+            <trkpt lon="-77.423121" lat="42.950381"></trkpt>
+            <trkpt lon="-77.422603" lat="42.950367"></trkpt>
+            <trkpt lon="-77.422231" lat="42.950251"></trkpt>
+            <trkpt lon="-77.421998" lat="42.950077"></trkpt>
+            <trkpt lon="-77.421395" lat="42.950014"></trkpt>
+            <trkpt lon="-77.420638" lat="42.950337"></trkpt>
+            <trkpt lon="-77.419765" lat="42.950433"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -5942,203 +5986,203 @@
                 <gpxx:DisplayColor>Blue</gpxx:DisplayColor>
             </gpxx:TrackExtension>
         </extensions>
-    <trkseg>
-      <trkpt lat="42.950433" lon="-77.419765">
-        <ele>224.6</ele>
-      </trkpt>
-      <trkpt lat="42.950414" lon="-77.419677">
-        <ele>224.6</ele>
-      </trkpt>
-      <trkpt lat="42.950228" lon="-77.419622">
-        <ele>222.6</ele>
-      </trkpt>
-      <trkpt lat="42.950071" lon="-77.419633">
-        <ele>222.4</ele>
-      </trkpt>
-      <trkpt lat="42.95004" lon="-77.419649">
-        <ele>222.2</ele>
-      </trkpt>
-      <trkpt lat="42.949839" lon="-77.419632">
-        <ele>222.2</ele>
-      </trkpt>
-      <trkpt lat="42.949635" lon="-77.419689">
-        <ele>222.0</ele>
-      </trkpt>
-      <trkpt lat="42.949148" lon="-77.419921">
-        <ele>223.0</ele>
-      </trkpt>
-      <trkpt lat="42.948961" lon="-77.419943">
-        <ele>223.8</ele>
-      </trkpt>
-      <trkpt lat="42.94868" lon="-77.420065">
-        <ele>225.4</ele>
-      </trkpt>
-      <trkpt lat="42.948541" lon="-77.420179">
-        <ele>227.4</ele>
-      </trkpt>
-      <trkpt lat="42.948438" lon="-77.4204">
-        <ele>229.6</ele>
-      </trkpt>
-      <trkpt lat="42.948417" lon="-77.420415">
-        <ele>229.8</ele>
-      </trkpt>
-      <trkpt lat="42.948343" lon="-77.420382">
-        <ele>230.8</ele>
-      </trkpt>
-      <trkpt lat="42.948201" lon="-77.420185">
-        <ele>231.0</ele>
-      </trkpt>
-      <trkpt lat="42.948133" lon="-77.420155">
-        <ele>230.4</ele>
-      </trkpt>
-      <trkpt lat="42.948036" lon="-77.420177">
-        <ele>230.8</ele>
-      </trkpt>
-      <trkpt lat="42.94794" lon="-77.4203">
-        <ele>231.2</ele>
-      </trkpt>
-      <trkpt lat="42.947904" lon="-77.420376">
-        <ele>231.8</ele>
-      </trkpt>
-      <trkpt lat="42.947879" lon="-77.420515">
-        <ele>231.8</ele>
-      </trkpt>
-      <trkpt lat="42.947751" lon="-77.42065">
-        <ele>232.4</ele>
-      </trkpt>
-      <trkpt lat="42.947654" lon="-77.420839">
-        <ele>231.6</ele>
-      </trkpt>
-      <trkpt lat="42.947556" lon="-77.420972">
-        <ele>231.6</ele>
-      </trkpt>
-      <trkpt lat="42.94748" lon="-77.420999">
-        <ele>231.4</ele>
-      </trkpt>
-      <trkpt lat="42.947424" lon="-77.420995">
-        <ele>230.6</ele>
-      </trkpt>
-      <trkpt lat="42.947314" lon="-77.421111">
-        <ele>228.4</ele>
-      </trkpt>
-      <trkpt lat="42.94714" lon="-77.421079">
-        <ele>228.0</ele>
-      </trkpt>
-      <trkpt lat="42.946988" lon="-77.421116">
-        <ele>228.0</ele>
-      </trkpt>
-      <trkpt lat="42.946917" lon="-77.421237">
-        <ele>228.2</ele>
-      </trkpt>
-      <trkpt lat="42.946883" lon="-77.421354">
-        <ele>227.8</ele>
-      </trkpt>
-      <trkpt lat="42.946807" lon="-77.421458">
-        <ele>228.2</ele>
-      </trkpt>
-      <trkpt lat="42.946749" lon="-77.421513">
-        <ele>228.6</ele>
-      </trkpt>
-      <trkpt lat="42.946634" lon="-77.421526">
-        <ele>229.6</ele>
-      </trkpt>
-      <trkpt lat="42.946425" lon="-77.421684">
-        <ele>230.6</ele>
-      </trkpt>
-      <trkpt lat="42.946314" lon="-77.421671">
-        <ele>231.8</ele>
-      </trkpt>
-      <trkpt lat="42.946207" lon="-77.421624">
-        <ele>233.2</ele>
-      </trkpt>
-      <trkpt lat="42.946163" lon="-77.421531">
-        <ele>233.0</ele>
-      </trkpt>
-      <trkpt lat="42.946022" lon="-77.421359">
-        <ele>231.8</ele>
-      </trkpt>
-      <trkpt lat="42.945937" lon="-77.421366">
-        <ele>232.0</ele>
-      </trkpt>
-      <trkpt lat="42.945741" lon="-77.421336">
-        <ele>233.8</ele>
-      </trkpt>
-      <trkpt lat="42.945721" lon="-77.421326">
-        <ele>234.2</ele>
-      </trkpt>
-      <trkpt lat="42.94565" lon="-77.421214">
-        <ele>234.6</ele>
-      </trkpt>
-      <trkpt lat="42.945569" lon="-77.421181">
-        <ele>235.2</ele>
-      </trkpt>
-      <trkpt lat="42.945439" lon="-77.421213">
-        <ele>234.2</ele>
-      </trkpt>
-      <trkpt lat="42.945382" lon="-77.421252">
-        <ele>233.8</ele>
-      </trkpt>
-      <trkpt lat="42.94528" lon="-77.42123">
-        <ele>234.0</ele>
-      </trkpt>
-      <trkpt lat="42.945112" lon="-77.421145">
-        <ele>233.8</ele>
-      </trkpt>
-      <trkpt lat="42.945052" lon="-77.42109">
-        <ele>233.6</ele>
-      </trkpt>
-      <trkpt lat="42.94498" lon="-77.420925">
-        <ele>232.8</ele>
-      </trkpt>
-      <trkpt lat="42.944951" lon="-77.420897">
-        <ele>232.8</ele>
-      </trkpt>
-      <trkpt lat="42.944796" lon="-77.420881">
-        <ele>234.2</ele>
-      </trkpt>
-      <trkpt lat="42.944694" lon="-77.420913">
-        <ele>233.8</ele>
-      </trkpt>
-      <trkpt lat="42.944661" lon="-77.420888">
-        <ele>234.0</ele>
-      </trkpt>
-      <trkpt lat="42.944647" lon="-77.420845">
-        <ele>234.0</ele>
-      </trkpt>
-      <trkpt lat="42.944578" lon="-77.420821">
-        <ele>234.2</ele>
-      </trkpt>
-      <trkpt lat="42.944511" lon="-77.420853">
-        <ele>234.8</ele>
-      </trkpt>
-      <trkpt lat="42.944482" lon="-77.420821">
-        <ele>235.0</ele>
-      </trkpt>
-      <trkpt lat="42.944431" lon="-77.420826">
-        <ele>233.8</ele>
-      </trkpt>
-      <trkpt lat="42.944348" lon="-77.420798">
-        <ele>234.0</ele>
-      </trkpt>
-      <trkpt lat="42.944271" lon="-77.420856">
-        <ele>234.4</ele>
-      </trkpt>
-      <trkpt lat="42.944213" lon="-77.42094">
-        <ele>234.8</ele>
-      </trkpt>
-      <trkpt lat="42.944139" lon="-77.421116">
-        <ele>235.0</ele>
-      </trkpt>
-      <trkpt lat="42.944122" lon="-77.421236">
-        <ele>234.8</ele>
-      </trkpt>
-      <trkpt lat="42.944077" lon="-77.421261">
-        <ele>234.6</ele>
-      </trkpt>
-      <trkpt lat="42.944007" lon="-77.421265">
-        <ele>234.6</ele>
-      </trkpt>
-    </trkseg>
+        <trkseg>
+            <trkpt lon="-77.419765" lat="42.950433">
+                <ele>224.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.419677" lat="42.950414">
+                <ele>224.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.419622" lat="42.950228">
+                <ele>222.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.419633" lat="42.950071">
+                <ele>222.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.419649" lat="42.950040">
+                <ele>222.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.419632" lat="42.949839">
+                <ele>222.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.419689" lat="42.949635">
+                <ele>222.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.419921" lat="42.949148">
+                <ele>223.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.419943" lat="42.948961">
+                <ele>223.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420065" lat="42.948680">
+                <ele>225.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.420179" lat="42.948541">
+                <ele>227.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.420400" lat="42.948438">
+                <ele>229.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.420415" lat="42.948417">
+                <ele>229.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420382" lat="42.948343">
+                <ele>230.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420185" lat="42.948201">
+                <ele>231.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.420155" lat="42.948133">
+                <ele>230.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.420177" lat="42.948036">
+                <ele>230.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420300" lat="42.947940">
+                <ele>231.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.420376" lat="42.947904">
+                <ele>231.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420515" lat="42.947879">
+                <ele>231.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420650" lat="42.947751">
+                <ele>232.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.420839" lat="42.947654">
+                <ele>231.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.420972" lat="42.947556">
+                <ele>231.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.420999" lat="42.947480">
+                <ele>231.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.420995" lat="42.947424">
+                <ele>230.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.421111" lat="42.947314">
+                <ele>228.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.421079" lat="42.947140">
+                <ele>228.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.421116" lat="42.946988">
+                <ele>228.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.421237" lat="42.946917">
+                <ele>228.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.421354" lat="42.946883">
+                <ele>227.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421458" lat="42.946807">
+                <ele>228.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.421513" lat="42.946749">
+                <ele>228.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.421526" lat="42.946634">
+                <ele>229.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.421684" lat="42.946425">
+                <ele>230.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.421671" lat="42.946314">
+                <ele>231.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421624" lat="42.946207">
+                <ele>233.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.421531" lat="42.946163">
+                <ele>233.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.421359" lat="42.946022">
+                <ele>231.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421366" lat="42.945937">
+                <ele>232.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.421336" lat="42.945741">
+                <ele>233.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421326" lat="42.945721">
+                <ele>234.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.421214" lat="42.945650">
+                <ele>234.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.421181" lat="42.945569">
+                <ele>235.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.421213" lat="42.945439">
+                <ele>234.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.421252" lat="42.945382">
+                <ele>233.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421230" lat="42.945280">
+                <ele>234.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.421145" lat="42.945112">
+                <ele>233.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421090" lat="42.945052">
+                <ele>233.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.420925" lat="42.944980">
+                <ele>232.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420897" lat="42.944951">
+                <ele>232.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420881" lat="42.944796">
+                <ele>234.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.420913" lat="42.944694">
+                <ele>233.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420888" lat="42.944661">
+                <ele>234.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.420845" lat="42.944647">
+                <ele>234.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.420821" lat="42.944578">
+                <ele>234.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.420853" lat="42.944511">
+                <ele>234.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420821" lat="42.944482">
+                <ele>235.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.420826" lat="42.944431">
+                <ele>233.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.420798" lat="42.944348">
+                <ele>234.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.420856" lat="42.944271">
+                <ele>234.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.420940" lat="42.944213">
+                <ele>234.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421116" lat="42.944139">
+                <ele>235.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.421236" lat="42.944122">
+                <ele>234.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.421261" lat="42.944077">
+                <ele>234.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.421265" lat="42.944007">
+                <ele>234.600000</ele>
+            </trkpt>
+        </trkseg>
     </trk>
     <trk>
         <name>seg:trail-senecatr-main:a36c78c4</name>
@@ -6148,37 +6192,37 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.432378" lat="42.938160"/>
-            <trkpt lon="-77.432085" lat="42.938044"/>
-            <trkpt lon="-77.430790" lat="42.938084"/>
-            <trkpt lon="-77.430271" lat="42.937790"/>
-            <trkpt lon="-77.430106" lat="42.937183"/>
-            <trkpt lon="-77.430019" lat="42.936413"/>
-            <trkpt lon="-77.430200" lat="42.935684"/>
-            <trkpt lon="-77.430364" lat="42.935260"/>
-            <trkpt lon="-77.430693" lat="42.935247"/>
-            <trkpt lon="-77.430961" lat="42.935841"/>
-            <trkpt lon="-77.431257" lat="42.935914"/>
-            <trkpt lon="-77.431493" lat="42.935755"/>
-            <trkpt lon="-77.431650" lat="42.935400"/>
-            <trkpt lon="-77.432154" lat="42.934998"/>
-            <trkpt lon="-77.432562" lat="42.934299"/>
-            <trkpt lon="-77.432983" lat="42.933463"/>
-            <trkpt lon="-77.433699" lat="42.932826"/>
-            <trkpt lon="-77.434161" lat="42.932729"/>
-            <trkpt lon="-77.434725" lat="42.932319"/>
-            <trkpt lon="-77.434761" lat="42.931844"/>
-            <trkpt lon="-77.433758" lat="42.930920"/>
-            <trkpt lon="-77.433745" lat="42.930687"/>
-            <trkpt lon="-77.434651" lat="42.929609"/>
-            <trkpt lon="-77.435020" lat="42.930113"/>
-            <trkpt lon="-77.435306" lat="42.930300"/>
-            <trkpt lon="-77.436098" lat="42.930509"/>
-            <trkpt lon="-77.436653" lat="42.930413"/>
-            <trkpt lon="-77.437021" lat="42.930172"/>
-            <trkpt lon="-77.437503" lat="42.929982"/>
-            <trkpt lon="-77.438109" lat="42.930108"/>
-            <trkpt lon="-77.438612" lat="42.930593"/>
+            <trkpt lon="-77.432378" lat="42.938160"></trkpt>
+            <trkpt lon="-77.432085" lat="42.938044"></trkpt>
+            <trkpt lon="-77.430790" lat="42.938084"></trkpt>
+            <trkpt lon="-77.430271" lat="42.937790"></trkpt>
+            <trkpt lon="-77.430106" lat="42.937183"></trkpt>
+            <trkpt lon="-77.430019" lat="42.936413"></trkpt>
+            <trkpt lon="-77.430200" lat="42.935684"></trkpt>
+            <trkpt lon="-77.430364" lat="42.935260"></trkpt>
+            <trkpt lon="-77.430693" lat="42.935247"></trkpt>
+            <trkpt lon="-77.430961" lat="42.935841"></trkpt>
+            <trkpt lon="-77.431257" lat="42.935914"></trkpt>
+            <trkpt lon="-77.431493" lat="42.935755"></trkpt>
+            <trkpt lon="-77.431650" lat="42.935400"></trkpt>
+            <trkpt lon="-77.432154" lat="42.934998"></trkpt>
+            <trkpt lon="-77.432562" lat="42.934299"></trkpt>
+            <trkpt lon="-77.432983" lat="42.933463"></trkpt>
+            <trkpt lon="-77.433699" lat="42.932826"></trkpt>
+            <trkpt lon="-77.434161" lat="42.932729"></trkpt>
+            <trkpt lon="-77.434725" lat="42.932319"></trkpt>
+            <trkpt lon="-77.434761" lat="42.931844"></trkpt>
+            <trkpt lon="-77.433758" lat="42.930920"></trkpt>
+            <trkpt lon="-77.433745" lat="42.930687"></trkpt>
+            <trkpt lon="-77.434651" lat="42.929609"></trkpt>
+            <trkpt lon="-77.435020" lat="42.930113"></trkpt>
+            <trkpt lon="-77.435306" lat="42.930300"></trkpt>
+            <trkpt lon="-77.436098" lat="42.930509"></trkpt>
+            <trkpt lon="-77.436653" lat="42.930413"></trkpt>
+            <trkpt lon="-77.437021" lat="42.930172"></trkpt>
+            <trkpt lon="-77.437503" lat="42.929982"></trkpt>
+            <trkpt lon="-77.438109" lat="42.930108"></trkpt>
+            <trkpt lon="-77.438612" lat="42.930593"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -6189,11 +6233,11 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.438612" lat="42.930593"/>
-            <trkpt lon="-77.439011" lat="42.930584"/>
-            <trkpt lon="-77.439599" lat="42.930097"/>
-            <trkpt lon="-77.440369" lat="42.929810"/>
-            <trkpt lon="-77.440779" lat="42.929400"/>
+            <trkpt lon="-77.438612" lat="42.930593"></trkpt>
+            <trkpt lon="-77.439011" lat="42.930584"></trkpt>
+            <trkpt lon="-77.439599" lat="42.930097"></trkpt>
+            <trkpt lon="-77.440369" lat="42.929810"></trkpt>
+            <trkpt lon="-77.440779" lat="42.929400"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -6204,16 +6248,16 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.413386" lat="42.971898"/>
-            <trkpt lon="-77.413449" lat="42.971620"/>
-            <trkpt lon="-77.413517" lat="42.971336"/>
-            <trkpt lon="-77.413540" lat="42.971097"/>
-            <trkpt lon="-77.413655" lat="42.970916"/>
-            <trkpt lon="-77.413658" lat="42.970856"/>
-            <trkpt lon="-77.413487" lat="42.970876"/>
-            <trkpt lon="-77.413065" lat="42.970754"/>
-            <trkpt lon="-77.412838" lat="42.970626"/>
-            <trkpt lon="-77.412532" lat="42.970619"/>
+            <trkpt lon="-77.413386" lat="42.971898"></trkpt>
+            <trkpt lon="-77.413449" lat="42.971620"></trkpt>
+            <trkpt lon="-77.413517" lat="42.971336"></trkpt>
+            <trkpt lon="-77.413540" lat="42.971097"></trkpt>
+            <trkpt lon="-77.413655" lat="42.970916"></trkpt>
+            <trkpt lon="-77.413658" lat="42.970856"></trkpt>
+            <trkpt lon="-77.413487" lat="42.970876"></trkpt>
+            <trkpt lon="-77.413065" lat="42.970754"></trkpt>
+            <trkpt lon="-77.412838" lat="42.970626"></trkpt>
+            <trkpt lon="-77.412532" lat="42.970619"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -6223,8 +6267,8 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.421265" lat="42.944007"/>
-            <trkpt lon="-77.425200" lat="42.943983"/>
+            <trkpt lon="-77.421265" lat="42.944007"></trkpt>
+            <trkpt lon="-77.425200" lat="42.943983"></trkpt>
         </trkseg>
     </trk>
     <trk>
@@ -6256,28 +6300,323 @@
             </gpxx:TrackExtension>
         </extensions>
         <trkseg>
-            <trkpt lon="-77.425200" lat="42.943983"/>
-            <trkpt lon="-77.425488" lat="42.943254"/>
-            <trkpt lon="-77.425419" lat="42.942848"/>
-            <trkpt lon="-77.425125" lat="42.942489"/>
-            <trkpt lon="-77.425001" lat="42.942245"/>
-            <trkpt lon="-77.423997" lat="42.942074"/>
-            <trkpt lon="-77.423132" lat="42.941905"/>
-            <trkpt lon="-77.422808" lat="42.941521"/>
-            <trkpt lon="-77.422511" lat="42.941188"/>
-            <trkpt lon="-77.421990" lat="42.940743"/>
-            <trkpt lon="-77.421937" lat="42.940449"/>
-            <trkpt lon="-77.422090" lat="42.940139"/>
-            <trkpt lon="-77.426442" lat="42.940064"/>
-            <trkpt lon="-77.426864" lat="42.939855"/>
-            <trkpt lon="-77.429851" lat="42.939942"/>
-            <trkpt lon="-77.430715" lat="42.939953"/>
-            <trkpt lon="-77.431586" lat="42.939861"/>
-            <trkpt lon="-77.431859" lat="42.940018"/>
-            <trkpt lon="-77.432046" lat="42.940008"/>
-            <trkpt lon="-77.431962" lat="42.938614"/>
-            <trkpt lon="-77.431962" lat="42.938614"/>
-            <trkpt lon="-77.432378" lat="42.938160"/>
+            <trkpt lon="-77.425200" lat="42.943983"></trkpt>
+            <trkpt lon="-77.425488" lat="42.943254"></trkpt>
+            <trkpt lon="-77.425419" lat="42.942848"></trkpt>
+            <trkpt lon="-77.425125" lat="42.942489"></trkpt>
+            <trkpt lon="-77.425001" lat="42.942245"></trkpt>
+            <trkpt lon="-77.423997" lat="42.942074"></trkpt>
+            <trkpt lon="-77.423132" lat="42.941905"></trkpt>
+            <trkpt lon="-77.422808" lat="42.941521"></trkpt>
+            <trkpt lon="-77.422511" lat="42.941188"></trkpt>
+            <trkpt lon="-77.421990" lat="42.940743"></trkpt>
+            <trkpt lon="-77.421937" lat="42.940449"></trkpt>
+            <trkpt lon="-77.422090" lat="42.940139"></trkpt>
+            <trkpt lon="-77.426442" lat="42.940064"></trkpt>
+            <trkpt lon="-77.426864" lat="42.939855"></trkpt>
+            <trkpt lon="-77.429851" lat="42.939942"></trkpt>
+            <trkpt lon="-77.430715" lat="42.939953"></trkpt>
+            <trkpt lon="-77.431586" lat="42.939861"></trkpt>
+            <trkpt lon="-77.431859" lat="42.940018"></trkpt>
+            <trkpt lon="-77.432046" lat="42.940008"></trkpt>
+            <trkpt lon="-77.431962" lat="42.938614"></trkpt>
+            <trkpt lon="-77.431962" lat="42.938614"></trkpt>
+            <trkpt lon="-77.432378" lat="42.938160"></trkpt>
         </trkseg>
     </trk>
+    <trk>
+        <name>seg:trail-senecatr-apple:e99d774f</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.425150" lat="42.952763">
+                <ele>215.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.425085" lat="42.952769">
+                <ele>215.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.425076" lat="42.952775">
+                <ele>215.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.425044" lat="42.952787">
+                <ele>215.900000</ele>
+            </trkpt>
+            <trkpt lon="-77.425020" lat="42.952791">
+                <ele>216.100000</ele>
+            </trkpt>
+            <trkpt lon="-77.424995" lat="42.952791">
+                <ele>216.300000</ele>
+            </trkpt>
+            <trkpt lon="-77.424983" lat="42.952790">
+                <ele>216.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.424972" lat="42.952788">
+                <ele>216.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.424961" lat="42.952785">
+                <ele>216.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424951" lat="42.952781">
+                <ele>216.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424943" lat="42.952776">
+                <ele>216.700000</ele>
+            </trkpt>
+            <trkpt lon="-77.424936" lat="42.952770">
+                <ele>216.700000</ele>
+            </trkpt>
+            <trkpt lon="-77.424930" lat="42.952764">
+                <ele>216.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.424925" lat="42.952757">
+                <ele>216.900000</ele>
+            </trkpt>
+            <trkpt lon="-77.424921" lat="42.952740">
+                <ele>217.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.424921" lat="42.952731">
+                <ele>217.100000</ele>
+            </trkpt>
+            <trkpt lon="-77.424925" lat="42.952710">
+                <ele>217.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.424943" lat="42.952664">
+                <ele>217.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.424949" lat="42.952653">
+                <ele>217.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.424970" lat="42.952604">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424977" lat="42.952579">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424981" lat="42.952553">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424982" lat="42.952540">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424982" lat="42.952528">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424981" lat="42.952515">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424981" lat="42.952502">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424977" lat="42.952476">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424976" lat="42.952464">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424970" lat="42.952425">
+                <ele>217.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.424970" lat="42.952411">
+                <ele>217.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.424969" lat="42.952398">
+                <ele>217.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.424971" lat="42.952370">
+                <ele>217.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.424982" lat="42.952327">
+                <ele>217.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.425002" lat="42.952284">
+                <ele>217.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.425028" lat="42.952241">
+                <ele>217.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.425149" lat="42.952074">
+                <ele>217.300000</ele>
+            </trkpt>
+            <trkpt lon="-77.425288" lat="42.951807">
+                <ele>217.700000</ele>
+            </trkpt>
+            <trkpt lon="-77.425300" lat="42.951777">
+                <ele>217.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.425315" lat="42.951731">
+                <ele>217.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.425322" lat="42.951700">
+                <ele>217.700000</ele>
+            </trkpt>
+            <trkpt lon="-77.425326" lat="42.951670">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.425324" lat="42.951656">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.425308" lat="42.951637">
+                <ele>217.600000</ele>
+            </trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-senecatr-apple:9749c77c</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.425308" lat="42.951637">
+                <ele>217.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.425289" lat="42.951620">
+                <ele>217.900000</ele>
+            </trkpt>
+            <trkpt lon="-77.425266" lat="42.951605">
+                <ele>217.900000</ele>
+            </trkpt>
+            <trkpt lon="-77.425222" lat="42.951587">
+                <ele>218.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.425206" lat="42.951582">
+                <ele>218.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.425151" lat="42.951570">
+                <ele>218.700000</ele>
+            </trkpt>
+            <trkpt lon="-77.424397" lat="42.951512">
+                <ele>217.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.424320" lat="42.951512">
+                <ele>217.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.424300" lat="42.951513">
+                <ele>217.900000</ele>
+            </trkpt>
+            <trkpt lon="-77.424281" lat="42.951513">
+                <ele>217.900000</ele>
+            </trkpt>
+            <trkpt lon="-77.422498" lat="42.951687">
+                <ele>220.300000</ele>
+            </trkpt>
+            <trkpt lon="-77.422477" lat="42.951687">
+                <ele>220.300000</ele>
+            </trkpt>
+            <trkpt lon="-77.422411" lat="42.951690">
+                <ele>220.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.422389" lat="42.951690">
+                <ele>220.500000</ele>
+            </trkpt>
+            <trkpt lon="-77.422367" lat="42.951691">
+                <ele>220.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.422346" lat="42.951691">
+                <ele>220.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.422324" lat="42.951692">
+                <ele>221.200000</ele>
+            </trkpt>
+            <trkpt lon="-77.422281" lat="42.951692">
+                <ele>221.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.422260" lat="42.951693">
+                <ele>221.800000</ele>
+            </trkpt>
+            <trkpt lon="-77.422049" lat="42.951689">
+                <ele>223.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.422034" lat="42.951687">
+                <ele>223.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.422020" lat="42.951687">
+                <ele>223.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.421987" lat="42.951684">
+                <ele>223.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.421980" lat="42.951683">
+                <ele>223.400000</ele>
+            </trkpt>
+            <trkpt lon="-77.421581" lat="42.951717"></trkpt>
+            <trkpt lon="-77.420377" lat="42.951702"></trkpt>
+            <trkpt lon="-77.418971" lat="42.951688"></trkpt>
+            <trkpt lon="-77.418033" lat="42.951594"></trkpt>
+            <trkpt lon="-77.417684" lat="42.951632"></trkpt>
+            <trkpt lon="-77.416462" lat="42.951815"></trkpt>
+            <trkpt lon="-77.415172" lat="42.952010"></trkpt>
+            <trkpt lon="-77.414435" lat="42.952062"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-senecatr-apple:7c17085a</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>DarkYellow</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.425310" lat="42.951633"></trkpt>
+            <trkpt lon="-77.425351" lat="42.951408"></trkpt>
+        </trkseg>
+    </trk>
+    <trk>
+        <name>seg:trail-senecatr-main:e8d927ee</name>
+        <extensions>
+            <gpxx:TrackExtension>
+                <gpxx:DisplayColor>Red</gpxx:DisplayColor>
+            </gpxx:TrackExtension>
+        </extensions>
+        <trkseg>
+            <trkpt lon="-77.423852" lat="42.958874">
+                <ele>205.700000</ele>
+            </trkpt>
+            <trkpt lon="-77.424100" lat="42.958881">
+                <ele>206.000000</ele>
+            </trkpt>
+            <trkpt lon="-77.424144" lat="42.958931">
+                <ele>206.600000</ele>
+            </trkpt>
+            <trkpt lon="-77.424098" lat="42.959126">
+                <ele>207.300000</ele>
+            </trkpt>
+            <trkpt lon="-77.424108" lat="42.959192">
+                <ele>207.100000</ele>
+            </trkpt>
+            <trkpt lon="-77.424180" lat="42.959389">
+                <ele>205.300000</ele>
+            </trkpt>
+            <trkpt lon="-77.424166" lat="42.959688">
+                <ele>203.300000</ele>
+            </trkpt>
+            <trkpt lon="-77.424069" lat="42.960068">
+                <ele>203.300000</ele>
+            </trkpt>
+        </trkseg>
+    </trk>
+    <wpt lon="-77.420781" lat="42.952366">
+        <name>point-sports:senecatr:discgolf</name>
+        <desc>{"name":"Disc Golf Course","parentIDs":["tsystem-senecatr","trail-senecatr-main","trail-senecatr-apple"],"url":"https://grdgc.org/courses/apple-farm-spartan-dgc"}</desc>
+    </wpt>
+    <wpt lon="-77.412140" lat="42.952449">
+        <name>point-poi:senecatr:applefarm</name>
+        <desc>{"name":"Victor Apple Farm","url":"https://www.thevictorapplefarm.com"}</desc>
+    </wpt>
+    <wpt lon="-77.424126" lat="42.956475">
+        <name>point-scenic:senecatr:greatbrook</name>
+        <desc>{"name":"Great Brook","parentIDs":["tsystem-senecatr","trail-senecatr-main"]}</desc>
+    </wpt>
+    <wpt lon="-77.425227" lat="42.952810">
+        <name>point-scenic:senecatr:gbrookbridge</name>
+        <desc>{"name":"Great Brook Bridge","shortName":"Bridge","parentIDs":["tsystem-senecatr","trail-senecatr-main"]}</desc>
+    </wpt>
+    <wpt lon="-77.426409" lat="42.951132">
+        <name>point-scenic:senecatr:beaverpond</name>
+        <desc>{"name":"Beaver Pond/Picnic Table","shortName":"Beaver Pond","parentIDs":["tsystem-senecatr","trail-senecatr-main"]}</desc>
+    </wpt>
 </gpx>

--- a/source/senecatr.json
+++ b/source/senecatr.json
@@ -19,7 +19,7 @@
         42.995138,
         -77.436878
       ],
-      "url": "http://www.victorhikingtrails.org/",
+      "url": "https://www.victorhikingtrails.org/",
       "keywords": "senaca",
       "isSearchable": true
     }
@@ -28,9 +28,8 @@
   },
   "trails": {
     "trail-senecatr-main": {
-      "url": "http://www.victorhikingtrails.org/",
+      "url": "https://www.victorhikingtrails.org/",
       "name": "Seneca Trail",
-      "length": 13.5,
       "color": "red",
       "SW": [
         42.9294,
@@ -43,6 +42,22 @@
       "keywords": "senaca",
       "style": "trailSystem",
       "isPrimary": true,
+      "parentID": "tsystem-senecatr"
+    },
+    "trail-senecatr-apple": {
+      "url": "https://www.victorhikingtrails.org/map/trails/apple_farm.php",
+      "name": "Apple Farm Trail",
+      "color": "yellow",
+      "SW": [
+        42.951408,
+        -77.425351
+      ],
+      "NE": [
+        42.952791,
+        -77.414435
+      ],
+      "keywords": "senaca seneca",
+      "isPrimary": false,
       "parentID": "tsystem-senecatr"
     }
   }

--- a/source/senecatr.json
+++ b/source/senecatr.json
@@ -58,7 +58,8 @@
       ],
       "keywords": "senaca seneca",
       "isPrimary": false,
-      "parentID": "tsystem-senecatr"
+      "parentID": "tsystem-senecatr",
+      "isSearchable": true
     }
   }
 }


### PR DESCRIPTION
- Adds El Camino trail for #12
- Genesee Riverway: adds scenic points for waterfall views. Updates name for Pont de Rennes Bridge. Adds some trail segments in downtown and High Falls neighborhoods
- Seneca Trail: adds some scenic points near the Apple Farm. Adds a POI for the Apple Farm itself, a POI for the disc golf course, and adds the yellow-blazed trail in that area
- Adds a new option to `query.rb` for conveniently creating a batch of random ID strings
- Documents the steps for updating map data

In Mapbox Studio, created a `pr-review-1` dataset/tileset/style that contains only the modified geojson files for review purposes. I've tested this in the iOS app.

Follow-up:

- Made some notes of additional changes in the city/along the river. Update GitHub issues with these notes